### PR TITLE
Add ScrollFactor option to change mouse/touchpad scroll speed

### DIFF
--- a/include/libinput-properties.h
+++ b/include/libinput-properties.h
@@ -154,6 +154,12 @@
 /* Scroll pixel distance: CARD32, 1 value, read-only */
 #define LIBINPUT_PROP_SCROLL_PIXEL_DISTANCE_DEFAULT "libinput Scrolling Pixel Distance Default"
 
+/* Scroll factor: FLOAT, 1 value, 32 bit */
+#define LIBINPUT_PROP_SCROLL_FACTOR "libinput Scrolling Factor"
+
+/* Scroll factor: FLOAT, 1 value, 32 bit, read-only */
+#define LIBINPUT_PROP_SCROLL_FACTOR_DEFAULT "libinput Scrolling Factor Default"
+
 /* Click method: BOOL read-only, 2 values in order buttonareas, clickfinger
    shows available click methods */
 #define LIBINPUT_PROP_CLICK_METHODS_AVAILABLE "libinput Click Methods Available"

--- a/man/libinput.man
+++ b/man/libinput.man
@@ -206,6 +206,11 @@ If disabled (the default), the
 button is considered logically down while held down and up once physically
 released.
 .TP 7
+.BI "Option \*qScrollFactor\*q \*q" float \*q
+Sets the scroll factor for scroll events. A higher value means faster scrolling.
+Applications that don't support xi2 input will instead receive scroll button events
+less or more frequently depending on the scroll factor value, instead of scrolling "smoother".
+.TP 7
 .BI "Option \*qScrollMethod\*q \*q" string \*q
 Enables a scroll method. Permitted values are
 .BR none ,


### PR DESCRIPTION
Add xorg option ScrollFactor.
Add xinput option "libinput Scrolling Factor".

This works well in xi2 applications where they receive the raw scroll value, however applications that use the core x11 protocol only for input receive a scroll button press. The frequency this scroll button press event is sent depends on the value of ScrollFactor, so it works in such applications as well but the scrolling wont be as "smooth" as if they used xi2.

gtk, qt, chromium (and electron) applications seem to use xi2 while firefox does not, unless you set the MOZ_USE_XINPUT2=1 environment variable.