### PR TITLE
xf86-input-libinput: make Emulate3Buttons a synonym for MiddleEmulation

### DIFF
--- a/man/libinput.man
+++ b/man/libinput.man
@@ -178,6 +178,15 @@ Enables left-handed button orientation, i.e. swapping left and right buttons.
 Enables middle button emulation.
 When enabled, pressing the left and right
 buttons simultaneously produces a middle mouse button click.
+A synonym
+.IP
+.BI "Option \*qEmulate3Buttons\*q \*q" bool \*q
+.IP
+is preserved for compatibility with
+.B evdev
+driver, with 
+.BI "\*qMiddleEmulation\*q
+having preference if both are set.
 .TP 7
 .BI "Option \*qNaturalScrolling\*q \*q" bool \*q
 Enables or disables natural scrolling behavior.

--- a/src/xf86libinput.c
+++ b/src/xf86libinput.c
@@ -3489,13 +3489,17 @@ static inline BOOL
 xf86libinput_parse_middleemulation_option(InputInfoPtr pInfo,
 					  struct libinput_device *device)
 {
-	BOOL enabled;
+	int enabled;
 
 	if (!libinput_device_config_middle_emulation_is_available(device))
 		return FALSE;
 
 	enabled = xf86SetBoolOption(pInfo->options,
 				    "MiddleEmulation",
+				    -1); /* returns -1 if the option has not been set */
+	if (enabled == -1)
+		enabled = xf86SetBoolOption(pInfo->options,
+				    "Emulate3Buttons",
 				    libinput_device_config_middle_emulation_get_default_enabled(device));
 	if (libinput_device_config_middle_emulation_set_enabled(device, enabled) !=
 	    LIBINPUT_CONFIG_STATUS_SUCCESS) {


### PR DESCRIPTION
This PR in intended to ease transition form evdev to libinput as the primary driver for mice.

Now libinput is a default driver for mice instead of evdev, and the commonly used option "Emulate3Buttons" stopped working. 

https://bbs.archlinux.org/viewtopic.php?id=286844

https://forums.freebsd.org/threads/where-to-put-xorgs-emulate3button-these-days.88837/

We could save them time and effort.

Fixes https://github.com/X11Libre/xserver/issues/461