### PR TITLE
meson.build: install the libinput-properties.h file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -146,6 +146,8 @@ configure_file(
 	install_dir: dir_man4
 )
 
+install_headers('include/libinput-properties.h', install_dir: dir_headers)
+
 install_data('conf/40-libinput.conf', install_dir: dir_xorg_conf)
 
 # Now generate config.h


### PR DESCRIPTION
Patch provided by Brice De Bruyne

Closes #67


Part-of: <https://gitlab.freedesktop.org/xorg/driver/xf86-input-libinput/-/merge_requests/71>