### PR TITLE
Fix input-libinput build failure if _GNU_SOURCE is not defined before stdio.h is included 

### DIFF
--- a/src/util-strings.c
+++ b/src/util-strings.c
@@ -23,6 +23,7 @@
  */
 
 #include "config.h"
+#define _GNU_SOURCE
 
 #include "util-strings.h"
 

--- a/src/util-strings.h
+++ b/src/util-strings.h
@@ -24,9 +24,6 @@
 
 #pragma once
 
-#include "config.h"
-#define _GNU_SOURCE
-
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>

--- a/src/xf86libinput.c
+++ b/src/xf86libinput.c
@@ -24,6 +24,7 @@
  */
 
 #include "config.h"
+#define _GNU_SOURCE
 
 #include <errno.h>
 #include <fcntl.h>


### PR DESCRIPTION
src: move _GNU_SOURCE definition before all includes in files that need `vasprintf()`

Build of input-libinput fails on GCC-11.2 although succeeds on GCC-14.2. Function `vasprintf()` becomes implicitle declared because its definition in stdio.h is guarded by `__GLIBC_USE_LIB_EXT2` which depends on `_USE_GNU`, which in turn depends on `_GNU_SOURCE`. `_GNU_SOURCE` is defined at the beginning of `util_string.h` before `#include <stdio.h>`, and this file is included by `util_strings.c` and `xf86libinput.c`. The latter file includes first a lot of headers in `/usr/include` and `/usr/include/xorg`, and finally `util_string.h`. If some of the previous header files `#include <stdio.h>`, then it is included first without `_GNU_SOURCE`, and `vasprintf()` is left undefined, which causes a build error.

This patch moves `#define _GNU_SOURCE` to `util_strings.c` and `xf86libinput.c` from `util_strings.h`, thus making `vasprintf()` declaration safe and independent of a specific compiler.

Fixes https://github.com/X11Libre/xf86-input-libinput/issues/12