### PR TITLE
fix warning on unhandled values

### DIFF
--- a/src/xf86libinput.c
+++ b/src/xf86libinput.c
@@ -2739,6 +2739,20 @@ xf86libinput_handle_event(struct libinput_event *event)
 			break;
 		case LIBINPUT_EVENT_SWITCH_TOGGLE:
 			break;
+
+		/* new libinput events we don't handle yet */
+#ifdef LIBINPUT_EVENT_GESTURE_HOLD_BEGIN
+		case LIBINPUT_EVENT_GESTURE_HOLD_BEGIN:
+			break;
+#endif
+#ifdef LIBINPUT_EVENT_GESTURE_HOLD_END
+		case LIBINPUT_EVENT_GESTURE_HOLD_END:
+			break;
+#endif
+#ifdef LIBINPUT_EVENT_TABLET_PAD_KEY
+		case LIBINPUT_EVENT_TABLET_PAD_KEY:
+			break;
+#endif
 	}
 
 out:


### PR DESCRIPTION
> /builds/metux/xf86-input-libinput/_builddir/../src/xf86libinput.c:2617:9: warning: enumeration value 'LIBINPUT_EVENT_TABLET_PAD_KEY' not handled in switch [-Wswitch]
>  2617 |         switch (type) {
>       |         ^~~~~~
> /builds/metux/xf86-input-libinput/_builddir/../src/xf86libinput.c:2617:9: warning: enumeration value 'LIBINPUT_EVENT_GESTURE_HOLD_BEGIN' not handled in switch [-Wswitch]
> /builds/metux/xf86-input-libinput/_builddir/../src/xf86libinput.c:2617:9: warning: enumeration value 'LIBINPUT_EVENT_GESTURE_HOLD_END' not handled in switch [-Wswitch]