### PR TITLE
disable pointless warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,8 @@ m4_ifndef([XORG_MACROS_VERSION],
 XORG_MACROS_VERSION(1.8)
 XORG_DEFAULT_OPTIONS
 
+CFLAGS="$CFLAGS -Wno-declaration-after-statement"
+
 # Obtain compiler/linker options from server and required extensions
 PKG_CHECK_MODULES(XORG, [xorg-server >= 1.19] xproto [inputproto >= 2.2])
 PKG_CHECK_MODULES(LIBINPUT, [libinput >= 1.11.0])


### PR DESCRIPTION
Add -Wno-declaration-after-statement for suppressing pointless warnings on declarations after statement.