### PR TITLE
util-strings: don't crash the Xserver on memory alloc failure

### DIFF
--- a/src/util-strings.c
+++ b/src/util-strings.c
@@ -122,7 +122,9 @@ strv_from_string(const char *in, const char *separators, size_t *num_elements)
 	}
 
 	size_t strv_len = nelems + 1; /* NULL-terminated */
-	char **strv = zalloc(strv_len * sizeof *strv);
+	char **strv = calloc(strv_len, sizeof(*strv));
+	if (!strv)
+		return NULL;
 
 	size_t idx = 0;
 	const char *word;

--- a/src/util-strings.h
+++ b/src/util-strings.h
@@ -253,7 +253,10 @@ double_array_from_string(const char *in,
 	if(!strv)
 		return result;
 
-	double *numv = zalloc(sizeof(double) * nelem);
+	double *numv = calloc(nelem, sizeof(double));
+	if (!numv)
+		goto out;
+
 	for (size_t idx = 0; idx < nelem; idx++) {
 		double val;
 		if (!safe_atod(strv[idx], &val))


### PR DESCRIPTION
It's only consumer already properly checking for NULL return value, so can directly use calloc() here, instead of zalloc() which is crashing the Xserver.