### PR TITLE
meson.build: add dep_libinput as dependency for the KANA check

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -65,7 +65,8 @@ if cc.has_function('libinput_device_config_click_set_clickfinger_button_map',
 		   dependencies: dep_libinput)
 	config_h.set('HAVE_LIBINPUT_CLICKFINGER_BUTTON_MAP', 1)
 endif
-if cc.has_header_symbol('libinput.h', 'LIBINPUT_LED_COMPOSE')
+if cc.has_header_symbol('libinput.h', 'LIBINPUT_LED_COMPOSE',
+			dependencies: dep_libinput)
 	config_h.set('HAVE_LIBINPUT_COMPOSE_AND_KANA', 1)
 endif
 


### PR DESCRIPTION
Xorg backport:

So meson can find the libinput.h header if libinput is in a nonstandard path.

Fixes: 0bcb60e74499 ("Add support for LIBINPUT_LED_COMPOSE/LIBINPUT_LED_KANA")
Part-of: <https://gitlab.freedesktop.org/xorg/driver/xf86-input-libinput/-/merge_requests/72>