### PR TITLE
Add support for the libinput plugin system

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -111,6 +111,17 @@ AC_LINK_IFELSE(
                [AC_MSG_RESULT([no])
                 [libinput_have_clickfinger_button_map=no]])
 
+AC_MSG_CHECKING([if libinput_plugin_system_load is available])
+AC_LINK_IFELSE(
+               [AC_LANG_PROGRAM([[#include <libinput.h>]],
+                                [[libinput_plugin_system_load_plugins(NULL, 0)]])],
+               [AC_MSG_RESULT([yes])
+                AC_DEFINE(HAVE_LIBINPUT_PLUGINS, [1],
+                          [libinput_plugin_system_load_plugins() is available])
+                [libinput_have_plugin_system=yes]],
+               [AC_MSG_RESULT([no])
+                [libinput_have_plugin_system=no]])
+
 LIBS=$OLD_LIBS
 CFLAGS=$OLD_CFLAGS
 

--- a/meson.build
+++ b/meson.build
@@ -69,6 +69,9 @@ if cc.has_header_symbol('libinput.h', 'LIBINPUT_LED_COMPOSE',
 			dependencies: dep_libinput)
 	config_h.set('HAVE_LIBINPUT_COMPOSE_AND_KANA', 1)
 endif
+if cc.has_function('libinput_plugin_system_load_plugins', dependencies: dep_libinput)
+	config_h.set('HAVE_LIBINPUT_PLUGINS', 1)
+endif
 
 dir_headers = get_option('sdkdir')
 if dir_headers == ''

--- a/src/xf86libinput.c
+++ b/src/xf86libinput.c
@@ -3874,6 +3874,10 @@ xf86libinput_init_driver_context(void)
 		/* we want all msgs, let the server filter */
 		libinput_log_set_priority(driver_context.libinput,
 					  LIBINPUT_LOG_PRIORITY_DEBUG);
+#if HAVE_LIBINPUT_PLUGINS
+		libinput_plugin_system_append_default_paths(driver_context.libinput);
+		libinput_plugin_system_load_plugins(driver_context.libinput, LIBINPUT_PLUGIN_SYSTEM_FLAG_NONE);
+#endif
 	} else {
 		libinput_ref(driver_context.libinput);
 	}


### PR DESCRIPTION
This is hardcoded to be enabled from the default paths (/usr/share and /etc) without any extra paths. If there is a need we can add xorg.conf options later but for now it will do.

Part-of: <https://gitlab.freedesktop.org/xorg/driver/xf86-input-libinput/-/merge_requests/73>