### PR TITLE
Revert "drop xorg-libinput.pc"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,9 @@ DISTCHECK_CONFIGURE_FLAGS = --with-xorg-module-dir='$${libdir}/xorg/modules' \
 SUBDIRS = src include man test
 MAINTAINERCLEANFILES = ChangeLog INSTALL
 
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = xorg-libinput.pc
+
 dist_xorgconf_DATA = conf/40-libinput.conf
 
 .PHONY: ChangeLog INSTALL

--- a/configure.ac
+++ b/configure.ac
@@ -153,5 +153,5 @@ AC_CONFIG_FILES([Makefile
 		 src/Makefile
 		 man/Makefile
 		 test/Makefile
-		])
+		 xorg-libinput.pc])
 AC_OUTPUT

--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,7 @@ project('xf86-input-libinput', 'c',
 
 driver_version = meson.project_version().split('.')
 
+dir_pkgconf	= get_option('prefix') / get_option('libdir') / 'pkgconfig'
 dir_man4	= get_option('prefix') / get_option('mandir') / 'man4'
 
 cc = meson.get_compiler('c')
@@ -122,6 +123,18 @@ test_draglock = executable('test-draglock',
 			 include_directories: include_directories('src'),
 			 install: false)
 test('test-draglock', test_draglock)
+
+
+conf_pkgconf = configuration_data()
+conf_pkgconf.set('PACKAGE_VERSION', meson.project_version())
+conf_pkgconf.set('sdkdir', dir_headers)
+
+configure_file(
+	input: 'xorg-libinput.pc.in',
+	output: 'xorg-libinput.pc',
+	configuration: conf_pkgconf,
+	install_dir: dir_pkgconf,
+)
 
 config_man = configuration_data()
 config_man.set('VERSION', '@0@ @1@'.format(meson.project_name(), meson.project_version()))

--- a/xorg-libinput.pc.in
+++ b/xorg-libinput.pc.in
@@ -1,0 +1,6 @@
+sdkdir=@sdkdir@
+
+Name: xorg-libinput
+Description: X.Org libinput input driver.
+Version: @PACKAGE_VERSION@
+Cflags: -I${sdkdir}


### PR DESCRIPTION
Apperently we cannot do this, because there are software which uses xorg-libinput.pc in build system:
* KDE plasma-desktop uses for libinput-properties.h header detection
* LXQT uses for libinput-properties.h

Closes: https://github.com/X11Libre/xf86-input-libinput/issues/25