### PR TITLE
(master) xf86libinput: fix use-after-free in update_mode_prop_cb()

### DIFF
--- a/src/xf86libinput.c
+++ b/src/xf86libinput.c
@@ -4328,7 +4328,7 @@ update_mode_prop_cb(ClientPtr client, pointer closure)
 {
 	struct mode_prop_state *state = closure;
 	InputInfoPtr pInfo = state->pInfo, tmp;
-	struct xf86libinput *driver_data = pInfo->private;
+	struct xf86libinput *driver_data;
 	BOOL found = FALSE;
 	XIPropertyValuePtr val;
 	int rc;
@@ -4351,6 +4351,12 @@ update_mode_prop_cb(ClientPtr client, pointer closure)
 	}
 	if (!found)
 		goto out;
+
+	/* Only safe to touch pInfo/its fields once the loop above has
+	 * confirmed it's still a live, registered device -- pInfo may
+	 * point at freed memory otherwise (device unplugged while this
+	 * WorkProc was queued). */
+	driver_data = pInfo->private;
 
 	rc = XIGetDeviceProperty(pInfo->dev,
 				 prop_mode_groups,


### PR DESCRIPTION
update_mode_prop_cb() is a QueueWorkProc callback that may run after the
InputInfoRec it was scheduled for has already been removed (device
unplugged while the WorkProc was pending). The function already
contains a liveness check for this (walking the current device list
and comparing against the saved device id/pointer), but it dereferenced
pInfo->private to compute driver_data *before* that check ran, reading
through pInfo while it may point at already-freed memory.

Move the driver_data lookup to after the liveness check confirms pInfo
is still a live, registered device; it's only used past that point
anyway.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
