### PR TITLE
(master) xf86libinput: fix option-list leak on OOM in xf86libinput_create_subdevice()

### DIFF
--- a/src/xf86libinput.c
+++ b/src/xf86libinput.c
@@ -3965,8 +3965,10 @@ xf86libinput_create_subdevice(InputInfoPtr pInfo,
 	xf86OptionListFree(options);
 
 	hotplug = calloc(1, sizeof(*hotplug));
-	if (!hotplug)
+	if (!hotplug) {
+		input_option_free_list(&iopts);
 		return;
+	}
 
 	hotplug->input_options = iopts;
 	hotplug->attrs = DuplicateInputAttributes(pInfo->attrs);


### PR DESCRIPTION
If the calloc() for 'hotplug' fails, the function returned without
freeing the InputOption chain (iopts) it had just built up from the
capability options a few lines above -- leaking that list and its
duplicated name/value strings.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
