### PR TITLE
xf86libinput: fix enabled_count leak when enabling a shared device fails

### DIFF
--- a/src/xf86libinput.c
+++ b/src/xf86libinput.c
@@ -387,29 +387,26 @@ xf86libinput_shared_enable(InputInfoPtr pInfo,
 	 * When the device is unplugged, the server now correctly finds two
 	 * devices on the real fd and releases them in order.
 	 */
-	shared_device->enabled_count++;
-	if (shared_device->enabled_count > 1) {
-		if (pInfo->flags & XI86_SERVER_FD) {
-			pInfo->options = xf86ReplaceIntOption(pInfo->options,
-							      "fd",
-							      shared_device->server_fd);
-		}
+	if (shared_device->enabled_count == 0) {
+		device = libinput_path_add_device(libinput, path);
+		if (!device)
+			return NULL;
 
-		return shared_device->device;
+		libinput_device_set_user_data(device, shared_device);
+		shared_device->device = libinput_device_ref(device);
+
+		if (pInfo->flags & XI86_SERVER_FD)
+			shared_device->server_fd = xf86CheckIntOption(pInfo->options,
+								      "fd",
+								      -1);
+	} else if (pInfo->flags & XI86_SERVER_FD) {
+		pInfo->options = xf86ReplaceIntOption(pInfo->options,
+						      "fd",
+						      shared_device->server_fd);
 	}
 
-	device = libinput_path_add_device(libinput, path);
-	if (!device)
-		return NULL;
-
-	libinput_device_set_user_data(device, shared_device);
-	shared_device->device = libinput_device_ref(device);
-
-	if (pInfo->flags & XI86_SERVER_FD)
-		shared_device->server_fd = xf86CheckIntOption(pInfo->options,
-							      "fd",
-							      -1);
-	return device;
+	shared_device->enabled_count++;
+	return shared_device->device;
 }
 
 static inline void


### PR DESCRIPTION
## Symptom

Racing VT switches can permanently kill all input for the session when
fds are server-managed. The reproducer below triggers it reliably under
libseat, because enable_seat() re-enables input devices even when the
libseat re-open failed, so DEVICE_ON runs with an invalid fd. Under
logind the same driver defect exists but is much harder to hit: input
enables are gated on a freshly delivered fd, so the race usually aborts
before DEVICE_ON is attempted. Any transient enable failure (device
unplugged mid-switch, udev init timeout) triggers it on either backend.

    chvt 1; sleep 0.1; chvt 2

Adjust the VT numbers and the sleep duration for your setup. Switching
back to VT1 manually then finds input dead, and it stays dead:
`xinput enable` fails silently, and only replugging the devices or
restarting the server recovers. The same applies to any other transient
enable failure (device unplugged mid-switch, udev init timeout).

Note: the same race can occasionally leave the screen black on the
switch back. That is a separate, pre-existing bug not addressed here. If
that happens, kill the display server, and try a higher sleep interval.

## Root cause

`xf86libinput_shared_enable()` increments `enabled_count` before calling
`libinput_path_add_device()`, which can fail at DEVICE_ON time. In the
reproducer, the brief switch to X's VT starts the per-device resume and
DEVICE_ON sequence; switching away again mid-resume makes DEVICE_ON fail
for devices whose fd was already withdrawn.

The server never pairs a failed DEVICE_ON with a DEVICE_OFF
(`DisableDevice` returns early for a device that never enabled), so the
increment is never rolled back. From then on every enable attempt of any
device sharing the node takes the already-enabled branch, returns the
NULL `shared_device->device`, fails, and leaks yet another increment.
`libinput_path_add_device()` is never retried, so the whole device group
stays dead even after the transient cause is gone.

The already-enabled branch also rewrites the sibling's "fd" option with
`shared_device->server_fd`, which is still 0 from calloc when the first
enable failed. Under libseat this is more than cosmetic:
`seatd_libseat_close_device()` reads the fd back from the options and
only guards against `fd < 0`, so the stale option leads to
`libseat_close_device()` plus `close(0)` on the next VT leave.

## Fix

Restructure the function so the count is incremented once, next to the
single successful return, after all error exits: returning non-NULL now
implies the count was taken, and a failed enable leaves the group
indistinguishable from never-enabled, so later attempts retry the add.
The first-enabler check becomes `enabled_count == 0`, matching
`xf86libinput_shared_is_enabled()`.

On success paths the behavior is unchanged.

## Testing

Reproduced the VT race under seatd (libseat): without the patch input
is permanently lost; with it, input recovers via `xinput enable`, see below.
Under systemd-logind the race leaves devices disabled for an unrelated,
recoverable reason (XI86_DEVICE_DISABLED handling) without reaching the
buggy path; the driver-side defect is backend-agnostic regardless.

    chvt 1; sleep 1; DISPLAY=:0 XAUTHORITY=/path/to/.Xauthority bash -c \
    'xinput list --id-only | while read -r id; do xinput enable "${id#* }"; done'
